### PR TITLE
Handle arrow keys for nudging and resizing views

### DIFF
--- a/DCIntrospect/DCIntrospect.h
+++ b/DCIntrospect/DCIntrospect.h
@@ -25,7 +25,7 @@
 
 #endif
 
-@interface DCIntrospect : NSObject <DCFrameViewDelegate, UITextFieldDelegate, UIWebViewDelegate>
+@interface DCIntrospect : NSObject <DCFrameViewDelegate, UITextViewDelegate, UIWebViewDelegate>
 {
 }
 
@@ -34,11 +34,12 @@
 @property (nonatomic, retain) UIGestureRecognizer *invokeGestureRecognizer;		// default: nil
 
 @property (nonatomic) BOOL on;
+@property (nonatomic) BOOL handleArrowKeys;
 @property (nonatomic) BOOL viewOutlines;
 @property (nonatomic) BOOL highlightNonOpaqueViews;
 @property (nonatomic) BOOL flashOnRedraw;
 @property (nonatomic, retain) DCFrameView *frameView;
-@property (nonatomic, retain) UITextField *inputField;
+@property (nonatomic, retain) UITextView *inputTextView;
 @property (nonatomic, retain) DCStatusBarOverlay *statusBarOverlay;
 
 @property (nonatomic, retain) NSMutableDictionary *objectNames;
@@ -75,7 +76,8 @@
 // Keyboard Capture //
 //////////////////////
 
-- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string;
+- (void)textViewDidChangeSelection:(UITextView *)textView;
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)string;
 
 /////////////////////////////////
 // Logging Code & Object Names //

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Selected keyboard shortcuts
 * Print accessibility properties and actions of selected view to console: `a`
 * Toggle all view outlines: `o`
 * Toggle highlighting non-opaque views: `O`
-* Nudge view left, right, up & down: `4 6 8 2` (use the numeric pad)
+* Nudge view left, right, up & down: `4 6 8 2` (use the numeric pad) or `← → ↑ ↓`
 * Print out the selected views' new frame to console after nudge/resize: `0`
 * Print selected views recursive description to console: `v`
 
@@ -80,11 +80,6 @@ Customizing Key Bindings
 --------------------------------------
 
 Edit the file `DCIntrospectSettings.h` to change key bindings.  You might want to change the key bindings if your using a laptop/wireless keyboard for development.
-
-To Do
---------
-
-* Add support for arrow keys for nudging views around, and maybe modifier keys for other things also.  If anyone knows how to do this please get in touch.  The iPhone app Prompt by Panic does this so I'm sure it's possible.
 
 License
 -----------


### PR DESCRIPTION
By using a UITextView instead of a UITextField, we are informed of selection change thanks to the textViewDidChangeSelection: delegate method. Crafting special text content allows to deduce what arrow keys (along with modifier keys) were pressed.
