### PR TITLE
Fixed armv6 compile errors

### DIFF
--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -50,7 +50,7 @@ static bool AmIBeingDebugged(void)
 }
 
 #if TARGET_CPU_ARM
-#define DEBUGSTOP(signal) __asm__ __volatile__ ("mov r0, %0\nmov r1, %1\nmov r12, #37\nswi 128\n" : : "r"(getpid ()), "r"(signal) : "r12", "r0", "r1", "cc");
+#define DEBUGSTOP(signal) __asm__ __volatile__ ("mov r0, %0\nmov r1, %1\nmov r12, %2\nswi 128\n" : : "r"(getpid ()), "r"(signal), "r"(37) : "r12", "r0", "r1", "cc");
 #define DEBUGGER do { int trapSignal = AmIBeingDebugged () ? SIGINT : SIGSTOP; DEBUGSTOP(trapSignal); if (trapSignal == SIGSTOP) { DEBUGSTOP (SIGINT); } } while (false);
 #else
 #define DEBUGGER do { int trapSignal = AmIBeingDebugged () ? SIGINT : SIGSTOP; __asm__ __volatile__ ("pushl %0\npushl %1\npush $0\nmovl %2, %%eax\nint $0x80\nadd $12, %%esp" : : "g" (trapSignal), "g" (getpid ()), "n" (37) : "eax", "cc"); } while (false);


### PR DESCRIPTION
We were having issues compiling against armv6. slightly re-wording the assembly seems to fix the compile errors, and we've confirmed that it hasn't broken the armv7 functionality. 
