### PR TITLE
Updated logPropertiesForObject to log all superclass properties between object & UIView

### DIFF
--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -1441,10 +1441,6 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 			[objectString appendFormat:@"multipleTouchEnabled: %@\n", (view.multipleTouchEnabled) ? @"YES" : @"NO"];
 			[objectString appendFormat:@"    gestureRecognizers: %@\n", (view.gestureRecognizers) ? [view.gestureRecognizers description] : @"nil"];
 		}
-		else if (inspectClass == UIScrollView.class || inspectClass == UIButton.class)
-		{
-			[objectString appendFormat:@"    Logging properties not currently supported for this class \"%@\".\n", inspectClass];
-		}
 		else
 		{
 			// Dump all properties of the class

--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -1398,10 +1398,6 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 	Class objectClass = [object class];
 	NSString *className = [NSString stringWithFormat:@"%@", objectClass];
 	
-	unsigned int count;
-	objc_property_t *properties = class_copyPropertyList(objectClass, &count);
-    size_t buf_size = 1024;
-    char *buffer = malloc(buf_size);
 	NSMutableString *outputString = [NSMutableString stringWithFormat:@"\n\n** %@", className];
 	
 	// list the class heirachy
@@ -1411,73 +1407,95 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 		[outputString appendFormat:@" : %@", superClass];
 		superClass = [superClass superclass];
 	}
+	[outputString appendString:@" ** \n"];
+
+	// dump properties of class and super classes, up to UIView
+	NSMutableString *propertyString = [NSMutableString string];
 	
-	[outputString appendString:@" ** \n\n"];
-	
-	if ([objectClass isSubclassOfClass:UIView.class])
+	Class inspectClass = objectClass;
+	while (inspectClass)
 	{
-		UIView *view = (UIView *)object;
-		// print out generic uiview properties
-		[outputString appendString:@"  ** UIView properties **\n"];
-		[outputString appendFormat:@"    tag: %i\n", view.tag];
-		[outputString appendFormat:@"    frame: %@ | ", NSStringFromCGRect(view.frame)];
-		[outputString appendFormat:@"bounds: %@ | ", NSStringFromCGRect(view.bounds)];
-		[outputString appendFormat:@"center: %@\n", NSStringFromCGPoint(view.center)];
-		[outputString appendFormat:@"    transform: %@\n", NSStringFromCGAffineTransform(view.transform)];
-		[outputString appendFormat:@"    autoresizingMask: %@\n", [self describeProperty:@"autoresizingMask" value:[NSNumber numberWithInt:view.autoresizingMask]]];
-		[outputString appendFormat:@"    autoresizesSubviews: %@\n", (view.autoresizesSubviews) ? @"YES" : @"NO"];
-		[outputString appendFormat:@"    contentMode: %@ | ", [self describeProperty:@"contentMode" value:[NSNumber numberWithInt:view.contentMode]]];
-		[outputString appendFormat:@"contentStretch: %@\n", NSStringFromCGRect(view.contentStretch)];
-		[outputString appendFormat:@"    backgroundColor: %@\n", [self describeColor:view.backgroundColor]];
-		[outputString appendFormat:@"    alpha: %.2f | ", view.alpha];
-		[outputString appendFormat:@"opaque: %@ | ", (view.opaque) ? @"YES" : @"NO"];
-		[outputString appendFormat:@"hidden: %@ | ", (view.hidden) ? @"YES" : @"NO"];
-		[outputString appendFormat:@"clips to bounds: %@ | ", (view.clipsToBounds) ? @"YES" : @"NO"];
-		[outputString appendFormat:@"clearsContextBeforeDrawing: %@\n", (view.clearsContextBeforeDrawing) ? @"YES" : @"NO"];
-		[outputString appendFormat:@"    userInteractionEnabled: %@ | ", (view.userInteractionEnabled) ? @"YES" : @"NO"];
-		[outputString appendFormat:@"multipleTouchEnabled: %@\n", (view.multipleTouchEnabled) ? @"YES" : @"NO"];
-		[outputString appendFormat:@"    gestureRecognizers: %@\n", (view.gestureRecognizers) ? [view.gestureRecognizers description] : @"nil"];
-		
-		[outputString appendString:@"\n"];
-	}
-	
-	[outputString appendFormat:@"  ** %@ properties **\n", objectClass];
-	
-	if (objectClass == UIScrollView.class || objectClass == UIButton.class)
-	{
-		[outputString appendString:@"    Logging properties not currently supported for this view.\n"];
-	}
-	else
-	{
-		
-		for (unsigned int i = 0; i < count; ++i)
+		NSMutableString *objectString = [NSMutableString string];
+		[objectString appendFormat:@"\n  ** %@ properties **\n", inspectClass];
+
+		if (inspectClass == UIView.class)
 		{
-			// get the property name and selector name
-			NSString *propertyName = [NSString stringWithCString:property_getName(properties[i]) encoding:NSUTF8StringEncoding];
-			
-			SEL sel = NSSelectorFromString(propertyName);
-			if ([object respondsToSelector:sel])
-			{
-				NSString *propertyDescription;
-				@try
-				{
-					// get the return object and type for the selector
-					NSString *returnType = [NSString stringWithUTF8String:[[object methodSignatureForSelector:sel] methodReturnType]];
-					id returnObject = [object valueForKey:propertyName];
-					if ([returnType isEqualToString:@"c"])
-						returnObject = [NSNumber numberWithBool:[returnObject intValue] != 0];
-					
-					propertyDescription = [self describeProperty:propertyName value:returnObject];
-				}
-				@catch (NSException *exception)
-				{
-					// Non KVC compliant properties, see also +workaroundUITextInputTraitsPropertiesBug
-					propertyDescription = @"N/A";
-				}
-				[outputString appendFormat:@"    %@: %@\n", propertyName, propertyDescription];
-			}
+			UIView *view = (UIView *)object;
+			// print out generic uiview properties
+			[objectString appendFormat:@"    tag: %i\n", view.tag];
+			[objectString appendFormat:@"    frame: %@ | ", NSStringFromCGRect(view.frame)];
+			[objectString appendFormat:@"bounds: %@ | ", NSStringFromCGRect(view.bounds)];
+			[objectString appendFormat:@"center: %@\n", NSStringFromCGPoint(view.center)];
+			[objectString appendFormat:@"    transform: %@\n", NSStringFromCGAffineTransform(view.transform)];
+			[objectString appendFormat:@"    autoresizingMask: %@\n", [self describeProperty:@"autoresizingMask" value:[NSNumber numberWithInt:view.autoresizingMask]]];
+			[objectString appendFormat:@"    autoresizesSubviews: %@\n", (view.autoresizesSubviews) ? @"YES" : @"NO"];
+			[objectString appendFormat:@"    contentMode: %@ | ", [self describeProperty:@"contentMode" value:[NSNumber numberWithInt:view.contentMode]]];
+			[objectString appendFormat:@"contentStretch: %@\n", NSStringFromCGRect(view.contentStretch)];
+			[objectString appendFormat:@"    backgroundColor: %@\n", [self describeColor:view.backgroundColor]];
+			[objectString appendFormat:@"    alpha: %.2f | ", view.alpha];
+			[objectString appendFormat:@"opaque: %@ | ", (view.opaque) ? @"YES" : @"NO"];
+			[objectString appendFormat:@"hidden: %@ | ", (view.hidden) ? @"YES" : @"NO"];
+			[objectString appendFormat:@"clips to bounds: %@ | ", (view.clipsToBounds) ? @"YES" : @"NO"];
+			[objectString appendFormat:@"clearsContextBeforeDrawing: %@\n", (view.clearsContextBeforeDrawing) ? @"YES" : @"NO"];
+			[objectString appendFormat:@"    userInteractionEnabled: %@ | ", (view.userInteractionEnabled) ? @"YES" : @"NO"];
+			[objectString appendFormat:@"multipleTouchEnabled: %@\n", (view.multipleTouchEnabled) ? @"YES" : @"NO"];
+			[objectString appendFormat:@"    gestureRecognizers: %@\n", (view.gestureRecognizers) ? [view.gestureRecognizers description] : @"nil"];
 		}
+		else if (inspectClass == UIScrollView.class || inspectClass == UIButton.class)
+		{
+			[objectString appendFormat:@"    Logging properties not currently supported for this class \"%@\".\n", inspectClass];
+		}
+		else
+		{
+			// Dump all properties of the class
+			unsigned int count;
+			objc_property_t *properties = class_copyPropertyList(inspectClass, &count);
+			size_t buf_size = 1024;
+			char *buffer = malloc(buf_size);
+			
+			for (unsigned int i = 0; i < count; ++i)
+			{
+				// get the property name and selector name
+				NSString *propertyName = [NSString stringWithCString:property_getName(properties[i]) encoding:NSUTF8StringEncoding];
+				
+				SEL sel = NSSelectorFromString(propertyName);
+				if ([object respondsToSelector:sel])
+				{
+					NSString *propertyDescription;
+					@try
+					{
+						// get the return object and type for the selector
+						NSString *returnType = [NSString stringWithUTF8String:[[object methodSignatureForSelector:sel] methodReturnType]];
+						id returnObject = [object valueForKey:propertyName];
+						if ([returnType isEqualToString:@"c"])
+							returnObject = [NSNumber numberWithBool:[returnObject intValue] != 0];
+						
+						propertyDescription = [self describeProperty:propertyName value:returnObject];
+					}
+					@catch (NSException *exception)
+					{
+						// Non KVC compliant properties, see also +workaroundUITextInputTraitsPropertiesBug
+						propertyDescription = @"N/A";
+					}
+					[objectString appendFormat:@"    %@: %@\n", propertyName, propertyDescription];
+				}
+			}
+			
+			free(properties);
+			free(buffer);
+		}
+		
+		[propertyString insertString:objectString atIndex:0];
+		
+		if (inspectClass == UIView.class)
+		{
+			break;
+		}
+
+		inspectClass = [inspectClass superclass];
 	}
+	
+	[outputString appendString:propertyString];
 	
 	// list targets if there are any
 	if ([object respondsToSelector:@selector(allTargets)])
@@ -1498,9 +1516,6 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 	
 	[outputString appendString:@"\n"];
 	NSLog(@"DCIntrospect: %@", outputString);
-	
-	free(properties);
-    free(buffer);
 }
 
 - (void)logAccessabilityPropertiesForObject:(id)object


### PR DESCRIPTION
Hi Pat,

I have updated logPropertiesForObject (the only method changed) to output properties for the class and all its super classes up to the UIView class.

This solved a problem for me when trying to dump properties of custom view/label subclasses. For example, dumping properties from UITableHeaderFooterViewLabel (private system class) from a table would not show the UILabel properties, which was what I was after.

I also changed the method to allow UIScrollView and UIButton class properties to be dumped, as I couldn't see a reason to hide these and I found the properties of these classes very useful.

Let me know what you think.

Cheers,
Chris
