### PR TITLE
Creates delegation of DCIntrospect and update the demo.

### DIFF
--- a/DCIntrospect/DCIntrospect.h
+++ b/DCIntrospect/DCIntrospect.h
@@ -17,6 +17,8 @@
 
 #ifdef DEBUG
 
+@protocol DCIntrospectDelegate;
+
 @interface UIView (debug)
 
 - (NSString *)recursiveDescription;
@@ -50,6 +52,9 @@
 @property (nonatomic, retain) NSMutableArray *currentViewHistory;
 
 @property (nonatomic) BOOL showingHelp;
+
+// Weak would have been better but the project is iOS 4 compatible.
+@property (nonatomic, assign) id<DCIntrospectDelegate> delegate;
 
 ///////////
 // Setup //
@@ -151,5 +156,11 @@
 - (void)fadeView:(UIView *)view toAlpha:(CGFloat)alpha;
 - (BOOL)view:(UIView *)view containsSubview:(UIView *)subview;
 - (BOOL)shouldIgnoreView:(UIView *)view;
+
+@end
+
+@protocol DCIntrospectDelegate <NSObject>
+
+- (BOOL)introspect:(DCIntrospect *)theIntrospect shouldConsumeKeyboardInput:(NSString *)theInput;
 
 @end

--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -77,6 +77,7 @@ DCIntrospect *sharedInstance = nil;
 @synthesize currentView, originalFrame, originalAlpha;
 @synthesize currentViewHistory;
 @synthesize showingHelp;
+@synthesize delegate;
 
 #pragma mark Setup
 
@@ -431,6 +432,10 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
     return NO;
   }
 
+    if ([self.delegate introspect:self shouldConsumeKeyboardInput:string]) {
+        return NO;
+    }
+    
 	if ([string isEqualToString:kDCIntrospectKeysInvoke])
 	{
 		[self invokeIntrospector];

--- a/DCIntrospectDemo/DCIntrospectDemo/DCIntrospectDemoViewController.h
+++ b/DCIntrospectDemo/DCIntrospectDemo/DCIntrospectDemoViewController.h
@@ -7,8 +7,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "DCIntrospect.h"
 
-@interface DCIntrospectDemoViewController : UIViewController <UITextFieldDelegate, UITableViewDelegate, UITableViewDataSource>
+@interface DCIntrospectDemoViewController : UIViewController <UITextFieldDelegate, UITableViewDelegate, UITableViewDataSource, DCIntrospectDelegate>
 {
 }
 

--- a/DCIntrospectDemo/DCIntrospectDemo/DCIntrospectDemoViewController.m
+++ b/DCIntrospectDemo/DCIntrospectDemo/DCIntrospectDemoViewController.m
@@ -16,6 +16,8 @@
 - (void)dealloc
 {
 	[[DCIntrospect sharedIntrospector] removeNamesForViewsInView:self.view];
+    // It is important for the delegate to be set as nil to prevent crashes.
+    [DCIntrospect sharedIntrospector].delegate = nil;
 
     [activityIndicator release];
 	[label release];
@@ -33,6 +35,8 @@
 {
 	[super viewDidLoad];
 
+    [DCIntrospect sharedIntrospector].delegate = self;
+    
 	// set the activity indicator to a non-integer frame for demonstration
 	self.activityIndicator.frame = CGRectOffset(self.activityIndicator.frame, 0.5, 0.0);
 	[[DCIntrospect sharedIntrospector] setName:@"activityIndicator" forObject:self.activityIndicator accessedWithSelf:YES];
@@ -106,6 +110,19 @@
 
 - (IBAction)sliderChanged:(id)sender
 {
+}
+
+#pragma mark - DCIntrospectDelegate methods
+
+- (BOOL)introspect:(DCIntrospect *)theIntrospect shouldConsumeKeyboardInput:(NSString *)theInput {
+    if ([theInput isEqualToString:@"z"]) {
+        if (self.label.backgroundColor == nil) {
+            self.label.backgroundColor = [UIColor greenColor];
+        } else {
+            self.label.backgroundColor = nil;
+        }
+    }
+    return NO;
 }
 
 @end


### PR DESCRIPTION
Allows user to extends useful functionality, like keyboard inputs, for their own use cases.
As the project is iOS 4 compatible, delegate property is set as assign, which requires the user to nil the delegate upon deallocation.
It would be better if we can make use of the weak property attribute instead which release the user the responsibility of setting the delegate to nil.
