### PR TITLE
Updated for iOS 6 deprecations

### DIFF
--- a/DCIntrospect/DCFrameView.m
+++ b/DCIntrospect/DCFrameView.m
@@ -36,7 +36,11 @@
 		self.touchPointLabel = [[[UILabel alloc] initWithFrame:CGRectZero] autorelease];
 		self.touchPointLabel.text = @"X 320 Y 480";
 		self.touchPointLabel.font = [UIFont boldSystemFontOfSize:12.0f];
+#if defined(__IPHONE_6_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0)
+		self.touchPointLabel.textAlignment = NSTextAlignmentCenter;
+#else
 		self.touchPointLabel.textAlignment = UITextAlignmentCenter;
+#endif
 		self.touchPointLabel.textColor = [UIColor whiteColor];
 		self.touchPointLabel.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.65f];
 		self.touchPointLabel.layer.cornerRadius = 5.5f;

--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -1448,7 +1448,9 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 			[objectString appendFormat:@"    autoresizingMask: %@\n", [self describeProperty:@"autoresizingMask" value:[NSNumber numberWithInt:view.autoresizingMask]]];
 			[objectString appendFormat:@"    autoresizesSubviews: %@\n", (view.autoresizesSubviews) ? @"YES" : @"NO"];
 			[objectString appendFormat:@"    contentMode: %@ | ", [self describeProperty:@"contentMode" value:[NSNumber numberWithInt:view.contentMode]]];
+#if !defined(__IPHONE_6_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0)
 			[objectString appendFormat:@"contentStretch: %@\n", NSStringFromCGRect(view.contentStretch)];
+#endif
 			[objectString appendFormat:@"    backgroundColor: %@\n", [self describeColor:view.backgroundColor]];
 			[objectString appendFormat:@"    alpha: %.2f | ", view.alpha];
 			[objectString appendFormat:@"opaque: %@ | ", (view.opaque) ? @"YES" : @"NO"];

--- a/DCIntrospect/DCStatusBarOverlay.m
+++ b/DCIntrospect/DCStatusBarOverlay.m
@@ -43,7 +43,11 @@
 
 		self.leftLabel = [[[UILabel alloc] initWithFrame:CGRectOffset(self.frame, 2.0f, 0.0f)] autorelease];
 		self.leftLabel.backgroundColor = [UIColor clearColor];
+#if defined(__IPHONE_6_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0)
+		self.leftLabel.textAlignment = NSTextAlignmentLeft;
+#else
 		self.leftLabel.textAlignment = UITextAlignmentLeft;
+#endif
 		self.leftLabel.font = [UIFont boldSystemFontOfSize:12.0f];
 		self.leftLabel.textColor = [UIColor colorWithWhite:0.97f alpha:1.0f];
 		self.leftLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
@@ -52,7 +56,11 @@
 		self.rightLabel = [[[UILabel alloc] initWithFrame:CGRectOffset(self.frame, -2.0f, 0.0f)] autorelease];
 		self.rightLabel.backgroundColor = [UIColor clearColor];
 		self.rightLabel.font = [UIFont boldSystemFontOfSize:12.0f];
+#if defined(__IPHONE_6_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0)
+		self.rightLabel.textAlignment = NSTextAlignmentRight;
+#else
 		self.rightLabel.textAlignment = UITextAlignmentRight;
+#endif
 		self.rightLabel.textColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
 		self.rightLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 		[self addSubview:self.rightLabel];

--- a/DCIntrospectDemo/DCIntrospectDemo/DCIntrospectDemoViewController.m
+++ b/DCIntrospectDemo/DCIntrospectDemo/DCIntrospectDemoViewController.m
@@ -38,6 +38,7 @@
 	[[DCIntrospect sharedIntrospector] setName:@"activityIndicator" forObject:self.activityIndicator accessedWithSelf:YES];
 }
 
+#if !defined(__IPHONE_6_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0)
 - (void)viewDidUnload
 {
     [self setActivityIndicator:nil];
@@ -45,6 +46,7 @@
 
 	[super viewDidUnload];
 }
+#endif
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {


### PR DESCRIPTION
Updated to compile without warnings for iOS 6 targets (not compiling deprecated method viewDidUnload, skipping output of contentStretch and updated deprecated constants to their new counter-parts).
