### PR TITLE
Shared instance should be declared static

### DIFF
--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -63,7 +63,7 @@ static bool AmIBeingDebugged(void)
 @end
 
 
-DCIntrospect *sharedInstance = nil;
+static DCIntrospect *sharedInstance = nil;
 
 @implementation DCIntrospect
 @synthesize keyboardBindingsOn, showStatusBarOverlay, invokeGestureRecognizer;


### PR DESCRIPTION
Hi,

Came across a clash between `DCIntrospect` and the `PayPalMPL` library; a symbol clash over `_sharedInstance`. Since PayPal's library is closed source, I can only modify `DCIntrospect`'s. In any case, the shared instance can and should be declared `static` and this prevents a clash between this and any other library.

Thanks,

J
