### PR TITLE
Fix warnings

### DIFF
--- a/DCIntrospect/DCFrameView.m
+++ b/DCIntrospect/DCFrameView.m
@@ -36,7 +36,7 @@
 		self.touchPointLabel = [[[UILabel alloc] initWithFrame:CGRectZero] autorelease];
 		self.touchPointLabel.text = @"X 320 Y 480";
 		self.touchPointLabel.font = [UIFont boldSystemFontOfSize:12.0f];
-		self.touchPointLabel.textAlignment = UITextAlignmentCenter;
+		self.touchPointLabel.textAlignment = NSTextAlignmentCenter;
 		self.touchPointLabel.textColor = [UIColor whiteColor];
 		self.touchPointLabel.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.65f];
 		self.touchPointLabel.layer.cornerRadius = 5.5f;

--- a/DCIntrospect/DCFrameView.m
+++ b/DCIntrospect/DCFrameView.m
@@ -69,6 +69,22 @@
 
 #pragma mark - Drawing/Display
 
+- (CGSize)safeSizeOfString:(NSString *)string withFont:(UIFont *)font {
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 70000)
+	return [string sizeWithFont:font];
+#else
+    return [string sizeWithAttributes:@{NSFontAttributeName:font}];
+#endif
+}
+
+- (void)safeDrawString:(NSString *)string inRect:(CGRect)rect withFont:(UIFont *)font {
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 70000)
+    [string drawInRect:rect withFont:font];
+#else
+    [string drawWithRect:rect options:0 attributes:@{NSFontAttributeName:font} context:nil];
+#endif
+}
+
 - (void)drawRect:(CGRect)rect
 {
 	CGContextRef context = UIGraphicsGetCurrentContext();
@@ -130,13 +146,14 @@
 	CGContextStrokePath(context);
 
 	NSString *leftDistanceString = (showAntialiasingWarning) ? [NSString stringWithFormat:@"%.1f", CGRectGetMinX(mainRectOffset)] : [NSString stringWithFormat:@"%.0f", CGRectGetMinX(mainRectOffset)];
-	CGSize leftDistanceStringSize = [leftDistanceString sizeWithFont:font];
-	[leftDistanceString drawInRect:CGRectMake(CGRectGetMinX(superRect) + 1.0f,
-											  floorf(CGRectGetMidY(adjustedMainRect)) - leftDistanceStringSize.height,
-											  leftDistanceStringSize.width,
-											  leftDistanceStringSize.height)
-						  withFont:font];
+    CGSize leftDistanceStringSize = [self safeSizeOfString:leftDistanceString withFont:font];
 
+    CGRect drawingRect = CGRectMake(CGRectGetMinX(superRect) + 1.0f,
+                                    floorf(CGRectGetMidY(adjustedMainRect)) - leftDistanceStringSize.height,
+                                    leftDistanceStringSize.width,
+                                    leftDistanceStringSize.height);
+    [self safeDrawString:leftDistanceString inRect:drawingRect withFont:font];
+    
 	// right side->edge
 	if (CGRectGetMaxX(self.mainRect) < CGRectGetMaxX(self.superRect))
 	{
@@ -145,24 +162,26 @@
 		CGContextStrokePath(context);
 	}
 	NSString *rightDistanceString = (showAntialiasingWarning) ? [NSString stringWithFormat:@"%.1f", CGRectGetMaxX(self.superRect) - CGRectGetMaxX(adjustedMainRect) - 0.5] : [NSString stringWithFormat:@"%.0f", CGRectGetMaxX(self.superRect) - CGRectGetMaxX(adjustedMainRect) - 0.5];
-	CGSize rightDistanceStringSize = [rightDistanceString sizeWithFont:font];
-	[rightDistanceString drawInRect:CGRectMake(CGRectGetMaxX(self.superRect) - rightDistanceStringSize.width - 1.0f,
-											   floorf(CGRectGetMidY(adjustedMainRect)) - 0.5f - rightDistanceStringSize.height,
-											   rightDistanceStringSize.width,
-											   rightDistanceStringSize.height)
-						   withFont:font];
+	CGSize rightDistanceStringSize = [self safeSizeOfString:rightDistanceString withFont:font];
+    
+    drawingRect = CGRectMake(CGRectGetMaxX(self.superRect) - rightDistanceStringSize.width - 1.0f,
+                             floorf(CGRectGetMidY(adjustedMainRect)) - 0.5f - rightDistanceStringSize.height,
+                             rightDistanceStringSize.width,
+                             rightDistanceStringSize.height);
+    [self safeDrawString:rightDistanceString inRect:drawingRect withFont:font];
 
 	// edge->top side
 	CGContextMoveToPoint(context, floorf(CGRectGetMidX(adjustedMainRect)) + 0.5f, self.superRect.origin.y);
 	CGContextAddLineToPoint(context, floorf(CGRectGetMidX(adjustedMainRect)) + 0.5f, CGRectGetMinY(adjustedMainRect));
 	CGContextStrokePath(context);
 	NSString *topDistanceString = (showAntialiasingWarning) ? [NSString stringWithFormat:@"%.1f",  mainRectOffset.origin.y] : [NSString stringWithFormat:@"%.0f", mainRectOffset.origin.y];
-	CGSize topDistanceStringSize = [topDistanceString sizeWithFont:font];
-	[topDistanceString drawInRect:CGRectMake(floorf(CGRectGetMidX(adjustedMainRect)) + 3.0f,
-											   floorf(CGRectGetMinY(self.superRect)),
-											   topDistanceStringSize.width,
-											   topDistanceStringSize.height)
-						   withFont:font];
+    CGSize topDistanceStringSize = [self safeSizeOfString:topDistanceString withFont:font];
+    drawingRect = CGRectMake(floorf(CGRectGetMidX(adjustedMainRect)) + 3.0f,
+                             floorf(CGRectGetMinY(self.superRect)),
+                             topDistanceStringSize.width,
+                             topDistanceStringSize.height);
+
+    [self safeDrawString:topDistanceString inRect:drawingRect withFont:font];
 
 	// bottom side->edge
 	if (CGRectGetMaxY(self.mainRect) < CGRectGetMaxY(self.superRect))
@@ -172,13 +191,12 @@
 		CGContextStrokePath(context);
 	}
 	NSString *bottomDistanceString = (showAntialiasingWarning) ? [NSString stringWithFormat:@"%.1f",  CGRectGetMaxY(self.superRect) - CGRectGetMaxY(mainRectOffset)] : [NSString stringWithFormat:@"%.0f", self.superRect.size.height - mainRectOffset.origin.y - mainRectOffset.size.height];
-	CGSize bottomDistanceStringSize = [bottomDistanceString sizeWithFont:font];
-	[bottomDistanceString drawInRect:CGRectMake(floorf(CGRectGetMidX(adjustedMainRect)) + 3.0f,
-												floorf(CGRectGetMaxY(self.superRect)) - bottomDistanceStringSize.height - 1.0f,
-												bottomDistanceStringSize.width,
-												bottomDistanceStringSize.height)
-							withFont:font];
-
+	CGSize bottomDistanceStringSize = [self safeSizeOfString:bottomDistanceString withFont:font];
+    drawingRect = CGRectMake(floorf(CGRectGetMidX(adjustedMainRect)) + 3.0f,
+                             floorf(CGRectGetMaxY(self.superRect)) - bottomDistanceStringSize.height - 1.0f,
+                             bottomDistanceStringSize.width,
+                             bottomDistanceStringSize.height);
+    [self safeDrawString:bottomDistanceString inRect:drawingRect withFont:font];
 }
 
 #pragma mark - Touch Handling
@@ -195,7 +213,7 @@
 	NSString *touchPontLabelString = [NSString stringWithFormat:@"%.0f, %.0f", touchPoint.x, touchPoint.y];
 	self.touchPointLabel.text = touchPontLabelString;
 
-	CGSize stringSize = [touchPontLabelString sizeWithFont:touchPointLabel.font];
+	CGSize stringSize = [self safeSizeOfString:touchPontLabelString withFont:touchPointLabel.font];
 	CGRect frame = CGRectMake(touchPoint.x - floorf(stringSize.width / 2.0f) - 5.0f,
 							  touchPoint.y - stringSize.height - labelDistance,
 							  stringSize.width + 11.0f,

--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -1448,7 +1448,9 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 			[objectString appendFormat:@"    autoresizingMask: %@\n", [self describeProperty:@"autoresizingMask" value:[NSNumber numberWithInt:view.autoresizingMask]]];
 			[objectString appendFormat:@"    autoresizesSubviews: %@\n", (view.autoresizesSubviews) ? @"YES" : @"NO"];
 			[objectString appendFormat:@"    contentMode: %@ | ", [self describeProperty:@"contentMode" value:[NSNumber numberWithInt:view.contentMode]]];
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED <= 60000)
 			[objectString appendFormat:@"contentStretch: %@\n", NSStringFromCGRect(view.contentStretch)];
+#endif
 			[objectString appendFormat:@"    backgroundColor: %@\n", [self describeColor:view.backgroundColor]];
 			[objectString appendFormat:@"    alpha: %.2f | ", view.alpha];
 			[objectString appendFormat:@"opaque: %@ | ", (view.opaque) ? @"YES" : @"NO"];

--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -993,9 +993,9 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 	{
 		switch ([value intValue])
 		{
-			case 0: return @"UITextAlignmentLeft";
-			case 1: return @"UITextAlignmentCenter";
-			case 2: return @"UITextAlignmentRight";
+			case 0: return @"NSTextAlignmentLeft";
+			case 1: return @"NSTextAlignmentCenter";
+			case 2: return @"NSTextAlignmentRight";
 			default: return nil;
 		}
 	}

--- a/DCIntrospect/DCStatusBarOverlay.m
+++ b/DCIntrospect/DCStatusBarOverlay.m
@@ -43,7 +43,7 @@
 
 		self.leftLabel = [[[UILabel alloc] initWithFrame:CGRectOffset(self.frame, 2.0f, 0.0f)] autorelease];
 		self.leftLabel.backgroundColor = [UIColor clearColor];
-		self.leftLabel.textAlignment = UITextAlignmentLeft;
+		self.leftLabel.textAlignment = NSTextAlignmentLeft;
 		self.leftLabel.font = [UIFont boldSystemFontOfSize:12.0f];
 		self.leftLabel.textColor = [UIColor colorWithWhite:0.97f alpha:1.0f];
 		self.leftLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
@@ -52,7 +52,7 @@
 		self.rightLabel = [[[UILabel alloc] initWithFrame:CGRectOffset(self.frame, -2.0f, 0.0f)] autorelease];
 		self.rightLabel.backgroundColor = [UIColor clearColor];
 		self.rightLabel.font = [UIFont boldSystemFontOfSize:12.0f];
-		self.rightLabel.textAlignment = UITextAlignmentRight;
+		self.rightLabel.textAlignment = NSTextAlignmentRight;
 		self.rightLabel.textColor = [UIColor colorWithWhite:0.9f alpha:1.0f];
 		self.rightLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 		[self addSubview:self.rightLabel];

--- a/DCIntrospectDemo/DCIntrospectDemo.xcodeproj/project.pbxproj
+++ b/DCIntrospectDemo/DCIntrospectDemo.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DCIntrospectDemo/DCIntrospectDemo-Prefix.pch";
+				GCC_VERSION = "";
 				GCC_WARN_SHADOW = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				INFOPLIST_FILE = "DCIntrospectDemo/DCIntrospectDemo-Info.plist";
@@ -292,6 +293,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DCIntrospectDemo/DCIntrospectDemo-Prefix.pch";
+				GCC_VERSION = "";
 				GCC_WARN_SHADOW = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				INFOPLIST_FILE = "DCIntrospectDemo/DCIntrospectDemo-Info.plist";


### PR DESCRIPTION
When building with some unnamed newer SDK, we get a handful of warnings.  Namely:
- Use `NSTextAlignment` instead of `UITextAlignment`.  The enums line up, so it's a safe replacement
- `NSString`'s `sizeWithFont:` is deprecated
- `NSString`'s `drawInRect:` is deprecated
- `UIView`'s `contentStretch` is deprecated

In addition, the demo app won't run b/c the compiler is hard coded to llvm-gcc4.2.  I switched this to the default (llvm 5.0 for newer Xcode's and whatever the default is for Xcode 4)

All of the changes have conditional compilation, so it still uses the old way if you're targeting 6 & below.
