### PR TITLE
Fixed infinite loop in workaroundUITextInputTraitsPropertiesBug

### DIFF
--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -147,17 +147,25 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 	for (unsigned int i = 0; i < count; i++)
 	{
 		Class class = classes[i];
-		if (class_getInstanceMethod(class, NSSelectorFromString(@"textInputTraits")))
-		{
+		if (class_getInstanceMethod(class, NSSelectorFromString(@"textInputTraits"))) {
 			IMP originalValueForKey = class_replaceMethod(class, @selector(valueForKey:), (IMP)UITextInputTraits_valueForKey, valueForKeyTypeEncoding);
-			if (!originalValueForKey)
-				originalValueForKey = (IMP)[objc_getAssociatedObject([class superclass], originalValueForKeyIMPKey) pointerValue];
-			if (!originalValueForKey)
-				originalValueForKey = class_getMethodImplementation([class superclass], @selector(valueForKey:));
-			
-			objc_setAssociatedObject(class, originalValueForKeyIMPKey, [NSValue valueWithPointer:(void *)originalValueForKey], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-		}
-	}
+            Class superclass = [class superclass];
+            
+            if (!originalValueForKey)
+                originalValueForKey = (IMP)[objc_getAssociatedObject(superclass, originalValueForKeyIMPKey) pointerValue];
+            
+            while (!originalValueForKey || originalValueForKey == (IMP)UITextInputTraits_valueForKey) {
+                superclass = [superclass superclass];
+                if (!superclass) {
+                    originalValueForKey = method_getImplementation(valueForKey);
+                    break;
+                }
+                originalValueForKey = class_getMethodImplementation(superclass, @selector(valueForKey:));
+            }
+            
+            objc_setAssociatedObject(class, originalValueForKeyIMPKey, [NSValue valueWithPointer:(void *)originalValueForKey], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+    }
 	free(classes);
 }
 

--- a/DCIntrospect/DCIntrospect.m
+++ b/DCIntrospect/DCIntrospect.m
@@ -153,8 +153,10 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
             
             if (!originalValueForKey)
                 originalValueForKey = (IMP)[objc_getAssociatedObject(superclass, originalValueForKeyIMPKey) pointerValue];
-            
-            while (!originalValueForKey || originalValueForKey == (IMP)UITextInputTraits_valueForKey) {
+            if (!originalValueForKey)
+            	originalValueForKey = class_getMethodImplementation(superclass, @selector(valueForKey:));
+
+            while (originalValueForKey == (IMP)UITextInputTraits_valueForKey) {
                 superclass = [superclass superclass];
                 if (!superclass) {
                     originalValueForKey = method_getImplementation(valueForKey);


### PR DESCRIPTION
In some cases, if classes were traversed in a particular order, the class's superclass would already have had `valueForKey` swizzled. In that case, `originalValueForKey` would be set to `UITextInputTraits_valueForKey`. This leads to an infinite loop in `UITextInputTraits_valueForKey`.

The fix is to traverse the class's heritage until a suitable `valueForKey:` implementation is found.
